### PR TITLE
Fix Ubuntu wezterm install

### DIFF
--- a/script/ubuntu.sh
+++ b/script/ubuntu.sh
@@ -44,7 +44,7 @@ check_and_install_wezterm() {
     curl -fsSL https://apt.fury.io/wez/gpg.key | sudo gpg --yes --dearmor -o /etc/apt/keyrings/wezterm-fury.gpg >>"$LOG_FILE" 2>&1
     echo 'deb [signed-by=/etc/apt/keyrings/wezterm-fury.gpg] https://apt.fury.io/wez/ * *' | sudo tee /etc/apt/sources.list.d/wezterm.list >>"$LOG_FILE" 2>&1
     sudo apt update >>"$LOG_FILE" 2>&1
-    sudo apt install wezterm >>"$LOG_FILE" 2>&1
+    sudo apt install -y wezterm >>"$LOG_FILE" 2>&1
     echo "wezterm ... OK"
   fi
 }


### PR DESCRIPTION
## Summary
- ensure wezterm installs without prompts on Ubuntu

## Testing
- `bats test/darwin/check_and_install.bats`

------
https://chatgpt.com/codex/tasks/task_e_683ff0fa17388332a399e0b5472b119a